### PR TITLE
Proposed feature: getServiceMock()

### DIFF
--- a/getservicemock.txt
+++ b/getservicemock.txt
@@ -1,0 +1,35 @@
+    /**
+     * Easily create a mock of any service in the DI container.
+     *
+     * @param string $id
+     * @param array $mockedMethodNames
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getServiceMock($id, $mockedMethodNames = array())
+    {
+        $definition = $this->getContainer()->getDefinition($id);
+        $argumentArray = $this->resolveArguments($definition->getArguments());
+
+        // Create the mock.
+        $mock = $this->getMock(
+            $definition->getClass(),
+            $mockedMethodNames,
+            $argumentArray
+        );
+
+        // Call all of the functions which were requested at instantiation time.
+        foreach ($definition->getMethodCalls() as $thisMethodCall) {
+            $methodName = $thisMethodCall[0];
+            $argumentDefinitions = $thisMethodCall[1];
+            $argumentArray = $this->resolveArguments($argumentDefinitions);
+
+            call_user_func_array(
+                array(
+                    $mock,
+                    $methodName,
+                ),
+                $argumentArray
+            );
+        }
+        return $mock;
+    }

--- a/getservicemock.txt
+++ b/getservicemock.txt
@@ -33,3 +33,23 @@
         }
         return $mock;
     }
+
+    /**
+     * Given an array of arguments that were given to a container definition, resolves all values.
+     *
+     * @param array $argumentDefinitions
+     * @return array
+     */
+    protected function resolveArguments(array $argumentDefinitions)
+    {
+        $argumentArray = array();
+        foreach ($argumentDefinitions as $thisArgument) {
+            if ($thisArgument instanceof Symfony\Component\DependencyInjection\Reference) {
+                /** @var \Symfony\Component\DependencyInjection\Reference $thisArgument */
+                $argumentArray[] = $this->getContainer()->get((string) $thisArgument);
+            } else {
+                $argumentArray[] = $thisArgument;
+            }
+        }
+        return $argumentArray;
+    }


### PR DESCRIPTION
I use this function _ALL THE TIME_ in my unit tests.

In my project, I have a subclass of PHPUnit_Framework_TestCase where I have copied this function. This makes it _incredibly_ easy to create mock objects from my services that are provided by the DI Container for unit testing.

```
$emailService = $this->getServiceMock('service.email', array('send'));

// Now we can make normal PHPUnit expectations....
$emailService->expects($this->once())->method('send'));
```

I'm not sure where in Symfony DI that this would go... perhaps a trait? I'm sure this would be something that many other devs find very useful.
