### PR TITLE
Fixed Dumper for used container build time

### DIFF
--- a/Dumper/PhpDumper.php
+++ b/Dumper/PhpDumper.php
@@ -223,7 +223,8 @@ EOF;
                 $files[$file] = "<?php\n".$c;
             }
             $files[$options['class'].'.php'] = $code.$this->endClass();
-            $hash = ucfirst(strtr(ContainerBuilder::hash($files), '._', 'xx'));
+            $toHash = $this->container->getParameter('kernel.container_build_time') ?? $files;
+            $hash = ucfirst(strtr(ContainerBuilder::hash($toHash), '._', 'xx'));
             $code = array();
 
             foreach ($files as $file => $c) {


### PR DESCRIPTION
As described in https://symfony.com/blog/new-in-symfony-reproducible-builds Symfony should allow to create static compiled cache. In many cases it works. However it doesn`t work when we change global parameter. $files variable will change, the hash also will be different, so folder name (Container{hash}) will change as well.

This pull request should solve the problem.