### PR TITLE
Add the name of the env to RuntimeException

### DIFF
--- a/EnvVarProcessor.php
+++ b/EnvVarProcessor.php
@@ -290,6 +290,6 @@ class EnvVarProcessor implements EnvVarProcessorInterface
             return trim($env);
         }
 
-        throw new RuntimeException(sprintf('Unsupported env var prefix "%s".', $prefix));
+        throw new RuntimeException(sprintf('Unsupported env var prefix "%s" for env name "%s".', $prefix, $name));
     }
 }


### PR DESCRIPTION
if you have the name of the env in the exception message it is much easier to find the error