### PR TITLE
added missing use container

### DIFF
--- a/Dumper/PhpDumper.php
+++ b/Dumper/PhpDumper.php
@@ -877,7 +877,7 @@ EOF;
                 $factory = sprintf('$this->factories%s[%s]', $definition->isPublic() ? '' : "['service_container']", $this->doExport($id));
                 $lazyloadInitialization = $definition->isLazy() ? '$lazyLoad = true' : '';
 
-                $c = sprintf("        %s = function (%s) {\n%s        };\n\n        return %1\$s();\n", $factory, $lazyloadInitialization, $c);
+                $c = sprintf("        %s = function (%s) use (\$container) {\n%s        };\n\n        return %1\$s();\n", $factory, $lazyloadInitialization, $c);
             }
 
             $code .= $c;


### PR DESCRIPTION
If you use not shared services, $container was not shared in closure.

Error-Message: Notice: Undefined variable: container