### PR TITLE
Update PhpDumper.php

### DIFF
--- a/Dumper/PhpDumper.php
+++ b/Dumper/PhpDumper.php
@@ -324,7 +324,9 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
 }
 
 require $autoloadFile;
+if (!class_exists({$options['class']})) {
 require __DIR__.'/Container{$hash}/{$options['class']}.php';
+}
 
 \$classes = [];
 


### PR DESCRIPTION
Fix for Compile Error: Cannot declare class ContainerId{ID}\srcApp_KernelTestDebugContainer, because the name is already in use