### PR TITLE
[DI] Add typehints to include() method signature

### DIFF
--- a/Loader/FileLoader.php
+++ b/Loader/FileLoader.php
@@ -50,7 +50,7 @@ abstract class FileLoader extends BaseFileLoader
      *
      * @param bool|string $ignoreErrors Whether errors should be ignored; pass "not_found" to ignore only when the loaded resource is not found
      */
-    public function import($resource, $type = null, $ignoreErrors = false, $sourceResource = null, $exclude = null)
+    public function import($resource, string $type = null, bool $ignoreErrors = false, string $sourceResource = null, $exclude = null)
     {
         $args = \func_get_args();
 


### PR DESCRIPTION
**Note: On the outside chance this can be a quick fix, I'm submitting this patch as-is. In the meantime I'll be reviewing the coding standards, testing procedures, and submission guidelines to work up a full-fledged PR.** 

Aligns method signature with BaseFileLoader which is the alias of the Symfony\Component\Config\Loader\FileLoader class.

I received the error below on a recent update to our Symfony packages:

```
===================BEGIN BACKTRACE===================
Declaration of

Symfony\Component\DependencyInjection\Loader\FileLoader::import($resource, $type = NULL, $ignoreErrors = false, $sourceResource = NULL, $exclude = NULL)

should be compatible with

Symfony\Component\Config\Loader\FileLoader::import($resource, ?string $type = NULL, bool $ignoreErrors = false, ?string $sourceResource = NULL, $exclude = NULL)

at ../vendor/symfony/dependency-injection/Loader/FileLoader.php 30:

  ../site.null/htdocs/index.php (7) calling require()
  ../bootstrap.php (41) calling {closure}()
  ../bootstrap.php (37) calling require_once()
  ../bootstrap/service_container.php (29) calling spl_autoload_call()
  ../vendor/composer/ClassLoader.php (322) calling Composer\Autoload\includeFile()
  ../vendor/composer/ClassLoader.php (444) calling include()
  ../vendor/symfony/dependency-injection/Loader/PhpFileLoader.php (24) calling spl_autoload_call()
  ../vendor/composer/ClassLoader.php (322) calling Composer\Autoload\includeFile()
  ../vendor/composer/ClassLoader.php (444) calling include()
====================END BACKTRACE====================
```