### PR TITLE
[DependencyInjection] Extend TaggedIterator and TaggedLocator Attributes with able to specify defaultIndexMethod for !tagged_iterator or ServiceLocator

### DIFF
--- a/Attribute/TaggedIterator.php
+++ b/Attribute/TaggedIterator.php
@@ -17,6 +17,7 @@ class TaggedIterator
     public function __construct(
         public string $tag,
         public ?string $indexAttribute = null,
+        public ?string $defaultIndexMethod = null,
     ) {
     }
 }

--- a/Attribute/TaggedLocator.php
+++ b/Attribute/TaggedLocator.php
@@ -17,6 +17,7 @@ class TaggedLocator
     public function __construct(
         public string $tag,
         public ?string $indexAttribute = null,
+        public ?string $defaultIndexMethod = null,
     ) {
     }
 }

--- a/Compiler/AutowirePass.php
+++ b/Compiler/AutowirePass.php
@@ -245,13 +245,13 @@ class AutowirePass extends AbstractRecursivePass
                 foreach ($parameter->getAttributes() as $attribute) {
                     if (TaggedIterator::class === $attribute->getName()) {
                         $attribute = $attribute->newInstance();
-                        $arguments[$index] = new TaggedIteratorArgument($attribute->tag, $attribute->indexAttribute);
+                        $arguments[$index] = new TaggedIteratorArgument($attribute->tag, $attribute->indexAttribute, $attribute->defaultIndexMethod);
                         break;
                     }
 
                     if (TaggedLocator::class === $attribute->getName()) {
                         $attribute = $attribute->newInstance();
-                        $arguments[$index] = new ServiceLocatorArgument(new TaggedIteratorArgument($attribute->tag, $attribute->indexAttribute, null, true));
+                        $arguments[$index] = new ServiceLocatorArgument(new TaggedIteratorArgument($attribute->tag, $attribute->indexAttribute, $attribute->defaultIndexMethod, true));
                         break;
                     }
                 }

--- a/Tests/Compiler/IntegrationTest.php
+++ b/Tests/Compiler/IntegrationTest.php
@@ -29,13 +29,17 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\Attribute\CustomMethodA
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Attribute\CustomParameterAttribute;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Attribute\CustomPropertyAttribute;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\BarTagClass;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FooBarClassWithDefaultIndexMethod;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooBarTaggedClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooBarTaggedForDefaultPriorityClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooTagClass;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FooTagClassWithDefaultIndexMethod;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\IteratorConsumer;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\IteratorConsumerWithDefaultIndexMethod;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\LocatorConsumer;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\LocatorConsumerConsumer;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\LocatorConsumerFactory;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\LocatorConsumerWithDefaultIndexMethod;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\LocatorConsumerWithoutIndex;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedService1;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedService2;
@@ -351,6 +355,30 @@ class IntegrationTest extends TestCase
         $this->assertSame(['bar_tab_class_with_defaultmethod' => $container->get(BarTagClass::class), 'foo' => $container->get(FooTagClass::class)], $param);
     }
 
+    public function testTaggedServiceWithDefaultIndexMethodConfiguredViaAttribute()
+    {
+        $container = new ContainerBuilder();
+        $container->register(BarTagClass::class)
+            ->setPublic(true)
+            ->addTag('foo_bar')
+        ;
+        $container->register(FooTagClass::class)
+            ->setPublic(true)
+            ->addTag('foo_bar')
+        ;
+        $container->register(IteratorConsumerWithDefaultIndexMethod::class)
+            ->setAutowired(true)
+            ->setPublic(true)
+        ;
+
+        $container->compile();
+
+        $s = $container->get(IteratorConsumerWithDefaultIndexMethod::class);
+
+        $param = iterator_to_array($s->getParam()->getIterator());
+        $this->assertSame(['bar_tag_class' => $container->get(BarTagClass::class), 'foo_tag_class' => $container->get(FooTagClass::class)], $param);
+    }
+
     public function testTaggedIteratorWithMultipleIndexAttribute()
     {
         $container = new ContainerBuilder();
@@ -430,6 +458,35 @@ class IntegrationTest extends TestCase
         $locator = $s->getLocator();
         self::assertSame($container->get(BarTagClass::class), $locator->get(BarTagClass::class));
         self::assertSame($container->get(FooTagClass::class), $locator->get(FooTagClass::class));
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testTaggedLocatorWithDefaultIndexMethodConfiguredViaAttribute()
+    {
+        $container = new ContainerBuilder();
+        $container->register(BarTagClass::class)
+            ->setPublic(true)
+            ->addTag('foo_bar')
+        ;
+        $container->register(FooTagClass::class)
+            ->setPublic(true)
+            ->addTag('foo_bar')
+        ;
+        $container->register(LocatorConsumerWithDefaultIndexMethod::class)
+            ->setAutowired(true)
+            ->setPublic(true)
+        ;
+
+        $container->compile();
+
+        /** @var LocatorConsumerWithoutIndex $s */
+        $s = $container->get(LocatorConsumerWithDefaultIndexMethod::class);
+
+        $locator = $s->getLocator();
+        self::assertSame($container->get(BarTagClass::class), $locator->get('bar_tag_class'));
+        self::assertSame($container->get(FooTagClass::class), $locator->get('foo_tag_class'));
     }
 
     /**

--- a/Tests/Fixtures/IteratorConsumerWithDefaultIndexMethod.php
+++ b/Tests/Fixtures/IteratorConsumerWithDefaultIndexMethod.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+
+final class IteratorConsumerWithDefaultIndexMethod
+{
+    public function __construct(
+        #[TaggedIterator(tag: 'foo_bar', defaultIndexMethod: 'getDefaultFooName')]
+        private iterable $param,
+    ) {
+    }
+
+    public function getParam(): iterable
+    {
+        return $this->param;
+    }
+}

--- a/Tests/Fixtures/LocatorConsumerWithDefaultIndexMethod.php
+++ b/Tests/Fixtures/LocatorConsumerWithDefaultIndexMethod.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
+
+final class LocatorConsumerWithDefaultIndexMethod
+{
+    public function __construct(
+        #[TaggedLocator(tag: 'foo_bar', defaultIndexMethod: 'getDefaultFooName')]
+        private ContainerInterface $locator,
+    ) {
+    }
+
+    public function getLocator(): ContainerInterface
+    {
+        return $this->locator;
+    }
+}


### PR DESCRIPTION
<!DOCTYPE html>

Q | A
-- | --
Branch? | 6.0
Bug fix? | no
New feature? | no
Deprecations? | no
License | MIT

<br class="Apple-interchange-newline">

Just extended two attributes that do not break compatibility, are optional and null.
The feature only allows you to do almost the same as in YAML files, the configuration specifying defaultIndexMethod for:
- \ Symfony \ Component \ DependencyInjection \ Attribute \ TaggedIterator
- \ Symfony \ Component \ DependencyInjection \ Attribute \ TaggedLocator